### PR TITLE
Fix channel whitelist parsing to match behavior with other implementations

### DIFF
--- a/deno/index.ts
+++ b/deno/index.ts
@@ -1,116 +1,120 @@
 /// <reference lib="deno.unstable" />
 // deno-lint-ignore-file no-explicit-any
 interface RefreshedResponse {
-    refreshed_urls?: [{ original?: string; refreshed?: string }];
+  refreshed_urls?: [{ original?: string; refreshed?: string }];
+}
+
+interface CachedURL {
+  href: string;
+  expires: Date;
+}
+
+const cache = new Map<string, CachedURL>();
+
+function parseValidURL(str: string): URL | false {
+  try {
+    return new URL(str);
+  } catch (_) {
+    return false;
   }
-  
-  interface CachedURL {
-    href: string;
-    expires: Date;
+}
+
+function handleOptions(request: Request): Response {
+  const methods = "GET, OPTIONS";
+
+  if (
+    request.headers.get("Origin") !== null &&
+    request.headers.get("Access-Control-Request-Method") &&
+    request.headers.get("Access-Control-Request-Headers") !== null
+  ) {
+    return new Response(null, {
+      headers: {
+        "Access-Control-Allow-Origin": request.headers.get("Origin") ?? "",
+        "Access-Control-Allow-Methods": methods,
+        "Access-Control-Allow-Headers": request.headers.get(
+          "Access-Control-Request-Headers",
+        ) ?? "",
+        "Access-Control-Max-Age": "86400",
+      },
+    });
+  } else {
+    return new Response(null, {
+      headers: {
+        "Allow": methods,
+      },
+    });
   }
-  
-  const cache = new Map<string, CachedURL>();
-  
-  function parseValidURL(str: string): URL | false {
-    try {
-      return new URL(str);
-    } catch (_) {
-      return false;
+}
+
+function withCORS(request: Request, response: Response): Response {
+  if (request.headers.get("Origin")) {
+    response.headers.set(
+      "Access-Control-Allow-Origin",
+      request.headers.get("Origin") ?? "",
+    );
+  }
+  return response;
+}
+
+function redirectResponse(
+  request: Request,
+  href: string,
+  expires: Date,
+  custom: "original" | "refreshed" | "memory" | "bucket",
+): Response {
+  const response = new Response("", {
+    status: 302,
+    statusText: "Found",
+  });
+  response.headers.set("Location", href);
+  response.headers.set("Expires", expires.toUTCString());
+  response.headers.set("x-discord-cdn-proxy", custom);
+
+  return withCORS(request, response);
+}
+
+Deno.serve(async (request: Request) => {
+  try {
+    if (request.method === "OPTIONS") {
+      return handleOptions(request);
     }
-  }
-  
-  function handleOptions(request: Request): Response {
-    const methods = "GET, OPTIONS";
-  
-    if (
-      request.headers.get("Origin") !== null &&
-      request.headers.get("Access-Control-Request-Method") &&
-      request.headers.get("Access-Control-Request-Headers") !== null
-    ) {
-      return new Response(null, {
-        headers: {
-          "Access-Control-Allow-Origin": request.headers.get("Origin") ?? "",
-          "Access-Control-Allow-Methods": methods,
-          "Access-Control-Allow-Headers": request.headers.get(
-            "Access-Control-Request-Headers",
-          ) ?? "",
-          "Access-Control-Max-Age": "86400",
-        },
-      });
-    } else {
-      return new Response(null, {
-        headers: {
-          "Allow": methods,
-        },
-      });
-    }
-  }
-  
-  function withCORS(request: Request, response: Response): Response {
-    if (request.headers.get("Origin")) {
-      response.headers.set(
-        "Access-Control-Allow-Origin",
-        request.headers.get("Origin") ?? "",
+
+    if (!Deno.env.get("DISCORD_TOKEN")) {
+      return withCORS(
+        request,
+        new Response(
+          "DISCORD_TOKEN is not configured",
+          { status: 400 },
+        ),
       );
     }
-    return response;
-  }
-  
-  function redirectResponse(
-    request: Request,
-    href: string,
-    expires: Date,
-    custom: "original" | "refreshed" | "memory" | "bucket",
-  ): Response {
-    const response = new Response("", {
-      status: 302,
-      statusText: "Found",
-    });
-    response.headers.set("Location", href);
-    response.headers.set("Expires", expires.toUTCString());
-    response.headers.set("x-discord-cdn-proxy", custom);
-  
-    return withCORS(request, response);
-  }
-  
-  Deno.serve(async (request: Request) => {
-    try {
-      if (request.method === "OPTIONS") {
-        return handleOptions(request);
-      }
-  
-      if (!Deno.env.get("DISCORD_TOKEN")) {
-        return withCORS(
-          request,
-          new Response(
-            "DISCORD_TOKEN is not configured",
-            { status: 400 },
-          ),
-        );
-      }
-  
-      const decoded = decodeURIComponent(request.url);
-      const urlStart = decoded.indexOf("?");
-      const attachmentURL = parseValidURL(decoded.substring(urlStart + 1));
-  
-      if (urlStart < 0 || attachmentURL === false) {
-        return withCORS(
-          request,
-          new Response(
-            "Provide Discord CDN url after ?. Example: https://your-web-site.com/?https://cdn.discordapp.com/attachments/channel/message/filename.ext",
-            {
-              status: 400,
-            },
-          ),
-        );
-      }
-  
-      const channel = attachmentURL.pathname.split("/")[2];
-  
-      // If CHANNELS are defined, ensure that provided channel is allowed.
-      if (
-        Deno.env.get("CHANNELS") && Deno.env.get("CHANNELS")?.includes(channel)
-      ) {
+
+    const decoded = decodeURIComponent(request.url);
+    const urlStart = decoded.indexOf("?");
+    const attachmentURL = parseValidURL(decoded.substring(urlStart + 1));
+
+    if (urlStart < 0 || attachmentURL === false) {
+      return withCORS(
+        request,
+        new Response(
+          "Provide Discord CDN url after ?. Example: https://your-web-site.com/?https://cdn.discordapp.com/attachments/channel/message/filename.ext",
+          {
+            status: 400,
+          },
+        ),
+      );
+    }
+
+    const channel = attachmentURL.pathname.split("/")[2];
+
+    if (Deno.env.get("CHANNELS")) {
+      let whitelistedChannelsEnv = Deno.env.get("CHANNELS")
+      let whitelistedChannels = whitelistedChannelsEnv
+        .replace(/[\[\]']/g, "")
+        .split(",")
+        .map(s => s.trim());
+
+      if (!whitelistedChannels.includes(channel)) {
         return withCORS(
           request,
           new Response("Provided channel is not allowed.", {
@@ -118,121 +122,121 @@ interface RefreshedResponse {
           }),
         );
       }
-  
-      const params = new URLSearchParams(attachmentURL.search);
-      
-      // Extract additional parameters (excluding ex, is, hm)
-      const additionalParams = new URLSearchParams();
-      for (const [key, value] of params) {
-        if (key !== 'ex' && key !== 'is' && key !== 'hm') {
-          additionalParams.set(key, value);
+    }
+
+    const params = new URLSearchParams(attachmentURL.search);
+
+    // Extract additional parameters (excluding ex, is, hm)
+    const additionalParams = new URLSearchParams();
+    for (const [key, value] of params) {
+      if (key !== 'ex' && key !== 'is' && key !== 'hm') {
+        additionalParams.set(key, value);
+      }
+    }
+
+    if (params.get("ex") && params.get("is") && params.get("hm")) {
+      const expr = new Date(parseInt(params.get("ex") ?? "", 16) * 1000);
+      if (expr.getTime() > Date.now()) {
+        return redirectResponse(request, attachmentURL.href, expr, "original");
+      }
+    }
+
+    const fileName = attachmentURL.pathname.split("/").pop() ?? "";
+    const cacheKey = additionalParams.size > 0 ? `${fileName}:${Array.from(additionalParams.entries()).sort(([a], [b]) => a.localeCompare(b)).map(([k, v]) => `${k}=${v}`).join('&')}` : fileName;
+
+    // check in-memory cache first
+    const cachedURL = cache.get(cacheKey);
+
+    if (cachedURL && cachedURL.expires.getTime() > Date.now()) {
+      return redirectResponse(
+        request,
+        cachedURL.href,
+        cachedURL.expires,
+        "memory",
+      );
+    }
+
+    // Check Deno KV (if configured)
+    // TODO: We could reconfigure this to work for Supabase Edge functions
+    // which could make this truly cross-platform like Deno functions usually are.
+    if (Deno.env.get("DISCORD_CDN_PROXY_BUCKET")) {
+      const kv = await Deno.openKv();
+
+      // check if kv has our object anywhere
+      const kvKey = `${channel}-${cacheKey}`;
+      const object = await kv.get<CachedURL>([kvKey]);
+
+      if (object.value !== null) {
+        const cachedURL: CachedURL = object.value!;
+        cachedURL.expires = new Date(cachedURL.expires);
+
+        if (cachedURL.expires.getTime() > Date.now()) {
+          // save the memory cache too
+          cache.set(cacheKey, cachedURL);
+          return redirectResponse(
+            request,
+            cachedURL.href,
+            cachedURL.expires,
+            "bucket",
+          );
         }
       }
-  
-      if (params.get("ex") && params.get("is") && params.get("hm")) {
-        const expr = new Date(parseInt(params.get("ex") ?? "", 16) * 1000);
-        if (expr.getTime() > Date.now()) {
-          return redirectResponse(request, attachmentURL.href, expr, "original");
-        }
+    }
+
+    const payload = {
+      method: "POST",
+      headers: {
+        "Authorization": `${Deno.env.get("DISCORD_TOKEN")}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ attachment_urls: [attachmentURL.href] }),
+    };
+
+    const response = await fetch(
+      "https://discord.com/api/v9/attachments/refresh-urls",
+      payload,
+    );
+
+    // if failed, return original Discord API response back
+    if (response.status !== 200) {
+      return withCORS(request, response);
+    }
+
+    const json: RefreshedResponse = await response.json();
+
+    if (
+      Array.isArray(json?.refreshed_urls) && json?.refreshed_urls[0].refreshed
+    ) {
+      const refreshedURL = new URL(json.refreshed_urls[0].refreshed);
+      const params = new URLSearchParams(refreshedURL.search);
+
+      // Add additional parameters back to the refreshed URL
+      for (const [key, value] of additionalParams) {
+        params.set(key, value);
       }
-  
-      const fileName = attachmentURL.pathname.split("/").pop() ?? "";
-      const cacheKey = additionalParams.size > 0 ? `${fileName}:${Array.from(additionalParams.entries()).sort(([a], [b]) => a.localeCompare(b)).map(([k, v]) => `${k}=${v}`).join('&')}` : fileName;
-  
-      // check in-memory cache first
-      const cachedURL = cache.get(cacheKey);
-  
-      if (cachedURL && cachedURL.expires.getTime() > Date.now()) {
-        return redirectResponse(
-          request,
-          cachedURL.href,
-          cachedURL.expires,
-          "memory",
-        );
-      }
-  
-      // Check Deno KV (if configured)
-      // TODO: We could reconfigure this to work for Supabase Edge functions
-      // which could make this truly cross-platform like Deno functions usually are.
+      refreshedURL.search = params.toString();
+
+      const expires = new Date(parseInt(params.get("ex") ?? "", 16) * 1000);
+
+      const cachedURL: CachedURL = { href: refreshedURL.href, expires };
+
+      // save to memory cache, then save on backing storage, if set
+      cache.set(cacheKey, cachedURL);
+
       if (Deno.env.get("DISCORD_CDN_PROXY_BUCKET")) {
         const kv = await Deno.openKv();
-  
-        // check if kv has our object anywhere
         const kvKey = `${channel}-${cacheKey}`;
-        const object = await kv.get<CachedURL>([kvKey]);
-  
-        if (object.value !== null) {
-          const cachedURL: CachedURL = object.value!;
-          cachedURL.expires = new Date(cachedURL.expires);
-  
-          if (cachedURL.expires.getTime() > Date.now()) {
-            // save the memory cache too
-            cache.set(cacheKey, cachedURL);
-            return redirectResponse(
-              request,
-              cachedURL.href,
-              cachedURL.expires,
-              "bucket",
-            );
-          }
-        }
+        await kv.set([kvKey], cachedURL, {
+          expireIn: expires.getTime(),
+        });
       }
-  
-      const payload = {
-        method: "POST",
-        headers: {
-          "Authorization": `${Deno.env.get("DISCORD_TOKEN")}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ attachment_urls: [attachmentURL.href] }),
-      };
-  
-      const response = await fetch(
-        "https://discord.com/api/v9/attachments/refresh-urls",
-        payload,
-      );
-  
-      // if failed, return original Discord API response back
-      if (response.status !== 200) {
-        return withCORS(request, response);
-      }
-  
-      const json: RefreshedResponse = await response.json();
-  
-      if (
-        Array.isArray(json?.refreshed_urls) && json?.refreshed_urls[0].refreshed
-      ) {
-        const refreshedURL = new URL(json.refreshed_urls[0].refreshed);
-        const params = new URLSearchParams(refreshedURL.search);
-        
-        // Add additional parameters back to the refreshed URL
-        for (const [key, value] of additionalParams) {
-          params.set(key, value);
-        }
-        refreshedURL.search = params.toString();
-        
-        const expires = new Date(parseInt(params.get("ex") ?? "", 16) * 1000);
-  
-        const cachedURL: CachedURL = { href: refreshedURL.href, expires };
-  
-        // save to memory cache, then save on backing storage, if set
-        cache.set(cacheKey, cachedURL);
-  
-        if (Deno.env.get("DISCORD_CDN_PROXY_BUCKET")) {
-          const kv = await Deno.openKv();
-          const kvKey = `${channel}-${cacheKey}`;
-          await kv.set([kvKey], cachedURL, {
-            expireIn: expires.getTime(),
-          });
-        }
-  
-        return redirectResponse(request, refreshedURL.href, expires, "refreshed");
-      }
-  
-      return withCORS(request, Response.json(json, { status: 400 }));
-    } catch (e: any) {
-      console.error(`Exception: ${e}`);
-      return withCORS(request, new Response(e, { status: 500 }));
+
+      return redirectResponse(request, refreshedURL.href, expires, "refreshed");
     }
-  });
-  
+
+    return withCORS(request, Response.json(json, { status: 400 }));
+  } catch (e: any) {
+    console.error(`Exception: ${e}`);
+    return withCORS(request, new Response(e, { status: 500 }));
+  }
+});


### PR DESCRIPTION
Previously this was just a 1-to-1 copy of the worker version, and it assumes the environment would work the same as CF Workers. However, it didn't work properly in Deno and Deno Deploy.

This PR matches the behavior properly with other implementations by properly parsing the Environment variable.